### PR TITLE
I missed my notify_hoptoad calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ tags
 .yardoc
 doc
 pkg
-*.gemspec

--- a/features/rails.feature
+++ b/features/rails.feature
@@ -215,3 +215,24 @@ Feature: Install the Gem in a Rails application
       | params        | secret: [FILTERED]                            |
       | session       | secret: [FILTERED]                            |
       | url           | http://example.com:123/test/index?param=value |
+
+  Scenario: Notify hoptoad within the controller
+    When I generate a new Rails application
+    And I configure the Hoptoad shim
+    And I configure my application to require the "hoptoad_notifier" gem
+    And I run the hoptoad generator with "-k myapikey"
+    And I define a response for "TestController#index":
+      """
+      session[:value] = "test"
+			notify_hoptoad(RuntimeError.new("some message"))
+      """
+    And I route "/test/index" to "test#index"
+    And I perform a request to "http://example.com:123/test/index?param=value"
+    Then I should receive the following Hoptoad notification:
+      | component     | test                                          |
+      | action        | index                                         |
+      | error message | RuntimeError: some message                    |
+      | error class   | RuntimeError                                  |
+      | session       | value: test                                   |
+      | parameters    | param: value                                  |
+      | url           | http://example.com:123/test/index?param=value |

--- a/hoptoad_notifier.gemspec
+++ b/hoptoad_notifier.gemspec
@@ -1,0 +1,47 @@
+# -*- encoding: utf-8 -*-
+
+Gem::Specification.new do |s|
+  s.name = %q{hoptoad_notifier}
+  s.version = "2.3.6"
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.authors = ["thoughtbot, inc"]
+  s.date = %q{2010-08-30}
+  s.email = %q{support@hoptoadapp.com}
+  s.extra_rdoc_files = ["README.rdoc"]
+  s.files = ["CHANGELOG", "INSTALL", "MIT-LICENSE", "Rakefile", "README.rdoc", "SUPPORTED_RAILS_VERSIONS", "TESTING.rdoc", "generators/hoptoad/hoptoad_generator.rb", "generators/hoptoad/lib/insert_commands.rb", "generators/hoptoad/lib/rake_commands.rb", "generators/hoptoad/templates/capistrano_hook.rb", "generators/hoptoad/templates/hoptoad_notifier_tasks.rake", "generators/hoptoad/templates/initializer.rb", "lib/hoptoad_notifier/backtrace.rb", "lib/hoptoad_notifier/capistrano.rb", "lib/hoptoad_notifier/configuration.rb", "lib/hoptoad_notifier/notice.rb", "lib/hoptoad_notifier/rack.rb", "lib/hoptoad_notifier/rails/action_controller_catcher.rb", "lib/hoptoad_notifier/rails/controller_methods.rb", "lib/hoptoad_notifier/rails/error_lookup.rb", "lib/hoptoad_notifier/rails/javascript_notifier.rb", "lib/hoptoad_notifier/rails.rb", "lib/hoptoad_notifier/rails3_tasks.rb", "lib/hoptoad_notifier/railtie.rb", "lib/hoptoad_notifier/sender.rb", "lib/hoptoad_notifier/tasks.rb", "lib/hoptoad_notifier/version.rb", "lib/hoptoad_notifier.rb", "lib/hoptoad_tasks.rb", "lib/rails/generators/hoptoad/hoptoad_generator.rb", "test/backtrace_test.rb", "test/catcher_test.rb", "test/configuration_test.rb", "test/helper.rb", "test/hoptoad_tasks_test.rb", "test/logger_test.rb", "test/notice_test.rb", "test/notifier_test.rb", "test/rack_test.rb", "test/rails_initializer_test.rb", "test/sender_test.rb", "rails/init.rb", "script/integration_test.rb", "lib/templates/javascript_notifier.erb", "lib/templates/rescue.erb"]
+  s.homepage = %q{http://www.hoptoadapp.com}
+  s.rdoc_options = ["--line-numbers", "--main", "README.rdoc"]
+  s.require_paths = ["lib"]
+  s.rubygems_version = %q{1.3.7}
+  s.summary = %q{Send your application errors to our hosted service and reclaim your inbox.}
+  s.test_files = ["test/backtrace_test.rb", "test/catcher_test.rb", "test/configuration_test.rb", "test/hoptoad_tasks_test.rb", "test/logger_test.rb", "test/notice_test.rb", "test/notifier_test.rb", "test/rack_test.rb", "test/rails_initializer_test.rb", "test/sender_test.rb"]
+
+  if s.respond_to? :specification_version then
+    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
+    s.specification_version = 3
+
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_runtime_dependency(%q<activesupport>, [">= 0"])
+      s.add_development_dependency(%q<activerecord>, [">= 0"])
+      s.add_development_dependency(%q<actionpack>, [">= 0"])
+      s.add_development_dependency(%q<jferris-mocha>, [">= 0"])
+      s.add_development_dependency(%q<nokogiri>, [">= 0"])
+      s.add_development_dependency(%q<shoulda>, [">= 0"])
+    else
+      s.add_dependency(%q<activesupport>, [">= 0"])
+      s.add_dependency(%q<activerecord>, [">= 0"])
+      s.add_dependency(%q<actionpack>, [">= 0"])
+      s.add_dependency(%q<jferris-mocha>, [">= 0"])
+      s.add_dependency(%q<nokogiri>, [">= 0"])
+      s.add_dependency(%q<shoulda>, [">= 0"])
+    end
+  else
+    s.add_dependency(%q<activesupport>, [">= 0"])
+    s.add_dependency(%q<activerecord>, [">= 0"])
+    s.add_dependency(%q<actionpack>, [">= 0"])
+    s.add_dependency(%q<jferris-mocha>, [">= 0"])
+    s.add_dependency(%q<nokogiri>, [">= 0"])
+    s.add_dependency(%q<shoulda>, [">= 0"])
+  end
+end

--- a/lib/hoptoad_notifier.rb
+++ b/lib/hoptoad_notifier.rb
@@ -1,7 +1,7 @@
 require 'net/http'
 require 'net/https'
 require 'rubygems'
-require 'activesupport'
+require 'active_support'
 require 'hoptoad_notifier/version'
 require 'hoptoad_notifier/configuration'
 require 'hoptoad_notifier/notice'

--- a/lib/hoptoad_notifier/rails/controller_methods.rb
+++ b/lib/hoptoad_notifier/rails/controller_methods.rb
@@ -6,8 +6,16 @@ module HoptoadNotifier
       # This method should be used for sending manual notifications while you are still
       # inside the controller. Otherwise it works like HoptoadNotifier.notify.
       def notify_hoptoad(hash_or_exception)
-        unless consider_all_requests_local || local_request?
+        unless hoptoad_local_request?
           HoptoadNotifier.notify(hash_or_exception, hoptoad_request_data)
+        end
+      end
+      
+      def hoptoad_local_request?
+        if defined?(::Rails::Railtie) #test for Rails 3
+          ::Rails.application.config.consider_all_requests_local || request.local?
+        else
+          consider_all_requests_local || local_request?
         end
       end
 

--- a/lib/hoptoad_notifier/rails/controller_methods.rb
+++ b/lib/hoptoad_notifier/rails/controller_methods.rb
@@ -12,7 +12,7 @@ module HoptoadNotifier
       end
       
       def hoptoad_local_request?
-        if defined?(::Rails::Railtie) #test for Rails 3
+        if defined?(::Rails.application.config)
           ::Rails.application.config.consider_all_requests_local || request.local?
         else
           consider_all_requests_local || local_request?

--- a/lib/hoptoad_notifier/railtie.rb
+++ b/lib/hoptoad_notifier/railtie.rb
@@ -21,7 +21,9 @@ module HoptoadNotifier
 
       if defined?(::ActionController::Base)
         require 'hoptoad_notifier/rails/javascript_notifier'
-
+        require 'hoptoad_notifier/rails/controller_methods'
+        
+        ::ActionController::Base.send(:include, HoptoadNotifier::Rails::ControllerMethods)
         ::ActionController::Base.send(:include, HoptoadNotifier::Rails::JavascriptNotifier)
       end
     end


### PR DESCRIPTION
There are several instances where I do not want the application to show an error page to the user, but I want to be informed of the error and notify_hoptoad did that for me.  Unfortunately, I kept on getting undefined method errors whenever I called notify_hoptoad from a controller in Rails 3.  This patch seeks to fix that.  It isn't elegant, but it seems to work.
