### PR TITLE
Allow bundle exec

### DIFF
--- a/lib/hoptoad_notifier/capistrano.rb
+++ b/lib/hoptoad_notifier/capistrano.rb
@@ -9,7 +9,7 @@ Capistrano::Configuration.instance(:must_exist).load do
     task :notify_hoptoad, :except => { :no_release => true } do
       rails_env = fetch(:hoptoad_env, fetch(:rails_env, "production"))
       local_user = ENV['USER'] || ENV['USERNAME']
-      executable = RUBY_PLATFORM.downcase.include?('mswin') ? 'rake.bat' : 'rake'
+      executable = RUBY_PLATFORM.downcase.include?('mswin') ? fetch(:rake, 'rake.bat') : fetch(:rake, 'rake')
       notify_command = "#{executable} hoptoad:deploy TO=#{rails_env} REVISION=#{current_revision} REPO=#{repository} USER=#{local_user}"
       notify_command << " API_KEY=#{ENV['API_KEY']}" if ENV['API_KEY']
       puts "Notifying Hoptoad of Deploy (#{notify_command})"


### PR DESCRIPTION
Hi,

An issue with this cap script is that it only allows a command of 'rake ...', when running just with bundler the usual method is to use the capistrano variable for rake, such as:

set :rake, 'bundle _#{BUNDLER_VERSION}_ exec rake'

So with cap this prefixes all capistrano rake tasks. Perfect for bundler only environments.

This commit uses the capistrano variable, if it exists.

So the resulting command on deploy is :

(with deploy.rb having):
set :rake,  "bundle _#{APPLICATION_BUNDLER_VERSION}_ exec rake"

(result of deploy):
Notifying Hoptoad of Deploy (bundle _1.0.7_ exec rake hoptoad:deploy TO=production REVISION=5a7ad7d1f298fa8a9968f37f36d3861aeb05d755 REPO=ssh://...mainline.git USER=tom)
Hoptoad Notification Complete.

rather than the current bug happening as saying gem Saikuro is not installed etc (as it should be using bundle).

Best regards,

Tom
