### PR TITLE
Fix default ignores in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -299,6 +299,7 @@ notifications (when #notify is called directly).
 
 Hoptoad ignores the following exceptions by default:
 
+  AbstractController::ActionNotFound
   ActiveRecord::RecordNotFound
   ActionController::RoutingError
   ActionController::InvalidAuthenticityToken


### PR DESCRIPTION
As per: https://github.com/thoughtbot/hoptoad_notifier/blob/master/CHANGELOG#L18

...to match

https://github.com/thoughtbot/hoptoad_notifier/blob/master/lib/hoptoad_notifier/configuration.rb#L110
