### PR TITLE
Updated initializer template

### DIFF
--- a/generators/hoptoad/templates/initializer.rb
+++ b/generators/hoptoad/templates/initializer.rb
@@ -1,6 +1,8 @@
 <% if Rails::VERSION::MAJOR < 3 && Rails::VERSION::MINOR < 2 -%>
 require 'hoptoad_notifier/rails'
 <% end -%>
-HoptoadNotifier.configure do |config|
-  config.api_key = <%= api_key_expression %>
+if defined?(HoptoadNotifier)
+  HoptoadNotifier.configure do |config|
+    config.api_key = <%= api_key_expression %>
+  end
 end


### PR DESCRIPTION
Hi,

Typically, I'll only include the hoptoad_notifier in my staging and production environments.  This can lead to issues in development when the initializer is executed.

This simple change checks for HoptoadNotifier before attempting to configure it.

Thanks,
Nathen
