### PR TITLE
Windows support for backtraces

### DIFF
--- a/lib/hoptoad_notifier/backtrace.rb
+++ b/lib/hoptoad_notifier/backtrace.rb
@@ -5,7 +5,8 @@ module HoptoadNotifier
     # Handles backtrace parsing line by line
     class Line
 
-      INPUT_FORMAT = %r{^([^:]+):(\d+)(?::in `([^']+)')?$}.freeze
+      # regexp (optionnally allowing leading X: for windows support)
+      INPUT_FORMAT = %r{^([a-zA-Z]?:?[^:]+):(\d+)(?::in `([^']+)')?$}.freeze
 
       # The file portion of the line (such as app/models/user.rb)
       attr_reader :file

--- a/test/backtrace_test.rb
+++ b/test/backtrace_test.rb
@@ -20,6 +20,25 @@ class BacktraceTest < Test::Unit::TestCase
     assert_equal 'app/controllers/users_controller.rb', line.file
     assert_equal 'index', line.method
   end
+  
+  should "parse a windows backtrace into lines" do
+    array = [
+      "C:/Program Files/Server/app/models/user.rb:13:in `magic'",
+      "C:/Program Files/Server/app/controllers/users_controller.rb:8:in `index'"
+    ]
+
+    backtrace = HoptoadNotifier::Backtrace.parse(array)
+
+    line = backtrace.lines.first
+    assert_equal '13', line.number
+    assert_equal 'C:/Program Files/Server/app/models/user.rb', line.file
+    assert_equal 'magic', line.method
+
+    line = backtrace.lines.last
+    assert_equal '8', line.number
+    assert_equal 'C:/Program Files/Server/app/controllers/users_controller.rb', line.file
+    assert_equal 'index', line.method
+  end
 
   should "be equal with equal lines" do
     one = build_backtrace_array


### PR DESCRIPTION
Hey,

I used Resque on Windows (which comes with a bundled hoptoad notifier) but kept getting empty backtraces in my HopToad messages.

I dived in a bit and fixed the regexp doing the parsing, allowing an optional leading letter and :, like regular drives are named on Windows.

The regexp could be made better to ensure it's either all ("C:") or nothing, but this new pattern works for me. Tests attached.

hth,

-- Thibaut
