### PR TITLE
Use Nokogiri instead of Builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ tags
 .yardoc
 doc
 pkg
-*.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -123,7 +123,7 @@ gemspec = Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.test_files   = Dir[*['test/**/*_test.rb']]
 
-  s.add_runtime_dependency("builder")
+  s.add_runtime_dependency("nokogiri")
   s.add_runtime_dependency("activesupport")
   s.add_development_dependency("activerecord")
   s.add_development_dependency("actionpack")
@@ -188,7 +188,7 @@ end
 
 task :cucumber => [:gemspec, :vendor_test_gems]
 
-def run_rails_cucumbr_task(version, additional_cucumber_args)
+def run_rails_cucumber_task(version, additional_cucumber_args)
   puts "Testing Rails #{version}"
   if version.empty?
     raise "No Rails version specified - make sure ENV['RAILS_VERSION'] is set, e.g. with `rake cucumber:rails:all`"
@@ -202,14 +202,14 @@ def define_rails_cucumber_tasks(additional_cucumber_args = '')
     RAILS_VERSIONS.each do |version|
       desc "Test integration of the gem with Rails #{version}"
       task version => [:gemspec, :vendor_test_gems] do
-        exit 1 unless run_rails_cucumbr_task(version, additional_cucumber_args)
+        exit 1 unless run_rails_cucumber_task(version, additional_cucumber_args)
       end
     end
 
     desc "Test integration of the gem with all Rails versions"
     task :all do
       results = RAILS_VERSIONS.map do |version|
-        run_rails_cucumbr_task(version, additional_cucumber_args)
+        run_rails_cucumber_task(version, additional_cucumber_args)
       end
 
       exit 1 unless results.all?

--- a/hoptoad_notifier.gemspec
+++ b/hoptoad_notifier.gemspec
@@ -1,18 +1,18 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
 require "hoptoad_notifier/version"
-require "rake"
 
 Gem::Specification.new do |s|
   s.name        = %q{hoptoad_notifier}
   s.version     = HoptoadNotifier::VERSION
   s.summary     = %q{Send your application errors to our hosted service and reclaim your inbox.}
 
-  s.files        = FileList['[A-Z]*', 'generators/**/*.*', 'lib/**/*.rb',
-                            'test/**/*.rb', 'rails/**/*.rb', 'script/*',
-                            'lib/templates/*.erb']
   s.require_path = 'lib'
-  s.test_files   = Dir[*['test/**/*_test.rb']]
+
+  s.files         = `git ls-files`.split("\n")
+  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.require_paths = ["lib"]
 
   s.add_runtime_dependency("nokogiri")
   s.add_runtime_dependency("activesupport")

--- a/hoptoad_notifier.gemspec
+++ b/hoptoad_notifier.gemspec
@@ -1,0 +1,29 @@
+# -*- encoding: utf-8 -*-
+$:.push File.expand_path("../lib", __FILE__)
+require "hoptoad_notifier/version"
+
+Gem::Specification.new do |s|
+  s.name        = %q{hoptoad_notifier}
+  s.version     = HoptoadNotifier::VERSION
+  s.summary     = %q{Send your application errors to our hosted service and reclaim your inbox.}
+
+  s.files        = FileList['[A-Z]*', 'generators/**/*.*', 'lib/**/*.rb',
+                            'test/**/*.rb', 'rails/**/*.rb', 'script/*',
+                            'lib/templates/*.erb']
+  s.require_path = 'lib'
+  s.test_files   = Dir[*['test/**/*_test.rb']]
+
+  s.add_runtime_dependency("builder")
+  s.add_runtime_dependency("activesupport")
+  s.add_development_dependency("activerecord")
+  s.add_development_dependency("actionpack")
+  s.add_development_dependency("bourne")
+  s.add_development_dependency("nokogiri")
+  s.add_development_dependency("shoulda")
+
+  s.authors = ["thoughtbot, inc"]
+  s.email   = %q{support@hoptoadapp.com}
+  s.homepage = "http://www.hoptoadapp.com"
+
+  s.platform = Gem::Platform::RUBY
+end

--- a/hoptoad_notifier.gemspec
+++ b/hoptoad_notifier.gemspec
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
 require "hoptoad_notifier/version"
+require "rake"
 
 Gem::Specification.new do |s|
   s.name        = %q{hoptoad_notifier}

--- a/hoptoad_notifier.gemspec
+++ b/hoptoad_notifier.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.test_files   = Dir[*['test/**/*_test.rb']]
 
-  s.add_runtime_dependency("builder")
+  s.add_runtime_dependency("nokogiri")
   s.add_runtime_dependency("activesupport")
   s.add_development_dependency("activerecord")
   s.add_development_dependency("actionpack")

--- a/lib/hoptoad_notifier/version.rb
+++ b/lib/hoptoad_notifier/version.rb
@@ -1,3 +1,3 @@
 module HoptoadNotifier
-  VERSION = "2.4.5".freeze
+  VERSION = "2.4.6".freeze
 end

--- a/lib/hoptoad_notifier/version.rb
+++ b/lib/hoptoad_notifier/version.rb
@@ -1,3 +1,3 @@
 module HoptoadNotifier
-  VERSION = "2.4.6".freeze
+  VERSION = "2.4.6"
 end


### PR DESCRIPTION
I changed the to_xml method on notice to use Nokogiri instead of Builder. With Builder, ruby1.9, rails 3.0.4 and other gems such as amqp I got the following error when using "rake hoptoad:test": uninitialized constant Builder::XmlBase::Symbol.
