### PR TITLE
Improve Rails 2.x / Isolate / Ruby 1.9.x compatibility with 'script/generate hoptoad' 

### DIFF
--- a/lib/hoptoad_notifier/tasks.rb
+++ b/lib/hoptoad_notifier/tasks.rb
@@ -8,7 +8,7 @@ namespace :hoptoad do
 
     require 'action_controller/test_process'
 
-    Dir["app/controllers/application*.rb"].each { |file| require(file) }
+    Dir["app/controllers/application*.rb"].each { |file| require(File.expand_path(file)) } 
 
     class HoptoadTestingException < RuntimeError; end
 


### PR DESCRIPTION
Hey there,

In trying to integrate Hoptoad with my Rails 2.x / Isolate / Ruby 1.9.x based app, I was unable to run "script/generate hoptoad" because of the relative path requires for "app/controllers/application*.rb". By turning these into absolute path requires, I was able to get the generator to run successfully.

This is the error I received that this pull request addresses:

*\* Invoke hoptoad:test (first_time)
*\* Invoke hoptoad:log_stdout (first_time)
*\* Execute hoptoad:log_stdout
*\* Invoke environment 
*\* Execute hoptoad:test
rake aborted!
no such file to load -- app/controllers/application_controller.rb
