### PR TITLE
improve exception handling for exceptions that implement to_hash

### DIFF
--- a/lib/hoptoad_notifier.rb
+++ b/lib/hoptoad_notifier.rb
@@ -131,11 +131,8 @@ module HoptoadNotifier
 
     def build_notice_for(exception, opts = {})
       exception = unwrap_exception(exception)
-      if exception.respond_to?(:to_hash)
-        opts = opts.merge(exception.to_hash)
-      else
-        opts = opts.merge(:exception => exception)
-      end
+      opts = opts.merge(:exception => exception)
+      opts = opts.merge(exception.to_hash) if exception.respond_to?(:to_hash)
       Notice.new(configuration.merge(opts))
     end
 

--- a/test/notifier_test.rb
+++ b/test/notifier_test.rb
@@ -82,6 +82,19 @@ class NotifierTest < Test::Unit::TestCase
     assert_sent(notice, notice_args)
   end
 
+  should "create and send a notice for an exception that responds to to_hash" do
+    set_public_env
+    exception = build_exception
+    notice = stub_notice!
+    notice_args = { :error_message => 'uh oh' }
+    exception.stubs(:to_hash).returns(notice_args)
+    stub_sender!
+
+    HoptoadNotifier.notify(exception)
+
+    assert_sent(notice, notice_args.merge(:exception => exception))
+  end
+
   should "create and sent a notice for an exception and hash" do
     set_public_env
     exception = build_exception


### PR DESCRIPTION
When an exception implements to_hash, it won't be added to the notification data as :exception. When to_hash isn't implemented specifically for hoptoad_notifier, this becomes a problem: The message remains the default ("Notification"), no stacktrace, etc.

This is a patch to always add the exception as :exception and then merge in the hash from to_hash if implemented. This way, the exception still can overwrite :exception, but notifications for exceptions with to_hash still can be read easily.

example exception: Savon::SOAP::Fault from gem savon

see: http://help.hoptoadapp.com/discussions/hoptoad-notifier-patches-and-discussion/67-exceptions-that-implement-to_hash-lose-all-of-their-useful-data
