### PR TITLE
Update API version, because hoptoad rejects notice messages with version attribute 2.0.

### DIFF
--- a/lib/hoptoad_notifier.rb
+++ b/lib/hoptoad_notifier.rb
@@ -19,7 +19,7 @@ require 'hoptoad_notifier/railtie' if defined?(Rails::Railtie)
 # Gem for applications to automatically post errors to the Hoptoad of their choice.
 module HoptoadNotifier
 
-  API_VERSION = "2.0"
+  API_VERSION = "2.1"
   LOG_PREFIX = "** [Hoptoad] "
 
   HEADERS = {


### PR DESCRIPTION
http://help.hoptoadapp.com/kb/api-2/notifier-api-version-21
...
notice/@version
Required. The version of the API being used. Should be set to "2.1"
