### PR TITLE
core_ext require

### DIFF
--- a/lib/hoptoad_notifier.rb
+++ b/lib/hoptoad_notifier.rb
@@ -3,8 +3,10 @@ require 'net/https'
 require 'rubygems'
 begin
   require 'active_support'
+  require 'active_support/core_ext'
 rescue LoadError
   require 'activesupport'
+  require 'activesupport/core_ext'
 end
 require 'hoptoad_notifier/version'
 require 'hoptoad_notifier/configuration'


### PR DESCRIPTION
Adding core_ext require as this is needed to pull in Object.blank? extension method

as described in support ticked: 

http://help.hoptoadapp.com/discussions/questions/516-unable-to-manually-send-a-hoptoad-notification-with-ruby-from-a-shell-script
