### PR TITLE
Project root as part of filename.

### DIFF
--- a/lib/hoptoad_notifier/configuration.rb
+++ b/lib/hoptoad_notifier/configuration.rb
@@ -96,7 +96,7 @@ module HoptoadNotifier
     DEFAULT_BACKTRACE_FILTERS = [
       lambda { |line|
         if defined?(HoptoadNotifier.configuration.project_root) && HoptoadNotifier.configuration.project_root.to_s != '' 
-          line.gsub(/#{HoptoadNotifier.configuration.project_root}/, "[PROJECT_ROOT]")
+          line.sub(/#{HoptoadNotifier.configuration.project_root}/, "[PROJECT_ROOT]")
         else
           line
         end

--- a/test/backtrace_test.rb
+++ b/test/backtrace_test.rb
@@ -82,6 +82,32 @@ class BacktraceTest < Test::Unit::TestCase
     end
   end
 
+  context "with a project root equals to a part of file name" do
+    setup do
+      # Heroku-like
+      @project_root = '/app'
+      HoptoadNotifier.configure {|config| config.project_root = @project_root }
+    end
+
+    teardown do
+      reset_config
+    end
+
+    should "filter out the project root" do
+      backtrace_with_root = HoptoadNotifier::Backtrace.parse(
+        ["#{@project_root}/app/models/user.rb:7:in `latest'",
+         "#{@project_root}/app/controllers/users_controller.rb:13:in `index'",
+         "/lib/something.rb:41:in `open'"],
+        :filters => default_filters)
+      backtrace_without_root = HoptoadNotifier::Backtrace.parse(
+        ["[PROJECT_ROOT]/app/models/user.rb:7:in `latest'",
+         "[PROJECT_ROOT]/app/controllers/users_controller.rb:13:in `index'",
+         "/lib/something.rb:41:in `open'"])
+
+      assert_equal backtrace_without_root, backtrace_with_root
+    end
+  end
+
   context "with a blank project root" do
     setup do
       HoptoadNotifier.configure {|config| config.project_root = '' }


### PR DESCRIPTION
Filtering project root on backtrace can break filename consistency if project root looks like a part of filename.
I've run into this on Heroku cedar stack where my app root is `/app`. So backtrace filtering makes `[PROJECT_ROOT][PROJECT_ROOT]/model/user.rb` from `/app/app/model/user.rb` which is wrong.

Substituting only the first occurrence of project root solves the problem.
