### PR TITLE
Dup the VERSION string in the gemspec so rubygems doesn't blow up trying 

### DIFF
--- a/hoptoad_notifier.gemspec
+++ b/hoptoad_notifier.gemspec
@@ -4,7 +4,7 @@ require "hoptoad_notifier/version"
 
 Gem::Specification.new do |s|
   s.name        = %q{hoptoad_notifier}
-  s.version     = HoptoadNotifier::VERSION
+  s.version     = HoptoadNotifier::VERSION.dup
   s.summary     = %q{Send your application errors to our hosted service and reclaim your inbox.}
 
   s.require_paths = ["lib"]


### PR DESCRIPTION
Dup the VERSION string in the gemspec so rubygems doesn't blow up trying to modify a frozen string

```
ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/version.rb:191:in `strip!': can't modify frozen string (RuntimeError)
ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/version.rb:191:in `initialize'
ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/version.rb:178:in `new'
ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/version.rb:178:in `create'
ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/specification.rb:2089:in `version='
hoptoad_notifier/hoptoad_notifier.gemspec:7:in `block in <main>'
```

Ran into this developing on 1.9.2.
