### PR TITLE
DRY-up generators by extracting common code and heroku-related code into separate modules.

### DIFF
--- a/generators/hoptoad/hoptoad_generator.rb
+++ b/generators/hoptoad/hoptoad_generator.rb
@@ -1,5 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + "/lib/insert_commands.rb")
 require File.expand_path(File.dirname(__FILE__) + "/lib/rake_commands.rb")
+require 'hoptoad_notifier/generator'
 
 class HoptoadGenerator < Rails::Generator::Base
   include HoptoadNotifier::Generator

--- a/generators/hoptoad/hoptoad_generator.rb
+++ b/generators/hoptoad/hoptoad_generator.rb
@@ -33,7 +33,9 @@ class HoptoadGenerator < Rails::Generator::Base
           m.append_to 'config/environment.rb', "require 'config/hoptoad'"
         end
       end
-      determine_api_key if heroku?
+      if heroku?
+        ENV['HOPTOAD_API_KEY'] ||= options[:api_key] || determine_api_key
+      end
       m.rake "hoptoad:test --trace", :generate_only => true
     end
   end
@@ -48,16 +50,17 @@ class HoptoadGenerator < Rails::Generator::Base
 
   def determine_api_key
     puts "Attempting to determine your API Key from Heroku..."
-    ENV['HOPTOAD_API_KEY'] = heroku_api_key
-    if ENV['HOPTOAD_API_KEY'].blank?
+    api_key = heroku_api_key
+    if api_key.blank?
       puts "... Failed."
       puts "WARNING: We were unable to detect the Hoptoad API Key from your Heroku environment."
       puts "Your Heroku application environment may not be configured correctly."
       exit 1
     else
       puts "... Done."
-      puts "Heroku's Hoptoad API Key is '#{ENV['HOPTOAD_API_KEY']}'"
+      puts "Heroku's Hoptoad API Key is '#{api_key}'"
     end
+    api_key
   end
 
   def heroku_api_key

--- a/generators/hoptoad/hoptoad_generator.rb
+++ b/generators/hoptoad/hoptoad_generator.rb
@@ -39,49 +39,6 @@ class HoptoadGenerator < Rails::Generator::Base
     end
   end
 
-  def api_key_expression
-    s = if options[:api_key]
-      "'#{options[:api_key]}'"
-    elsif options[:heroku]
-      "ENV['HOPTOAD_API_KEY']"
-    end
-  end
-
-  def determine_api_key
-    puts "Attempting to determine your API Key from Heroku..."
-    api_key = heroku_api_key
-    if api_key.blank?
-      puts "... Failed."
-      puts "WARNING: We were unable to detect the Hoptoad API Key from your Heroku environment."
-      puts "Your Heroku application environment may not be configured correctly."
-      exit 1
-    else
-      puts "... Done."
-      puts "Heroku's Hoptoad API Key is '#{api_key}'"
-    end
-    api_key
-  end
-
-  def heroku_api_key
-    cmd = heroku_cedar? ? 'run console' : 'console'
-    heroku_cmd(cmd, "'puts ENV[%{HOPTOAD_API_KEY}]'").split("\n").first
-  end
-
-  def heroku_cmd(cmd, input = nil)
-    app = " --app #{options[:app]}" if options[:app]
-    `heroku #{cmd} #{input} #{app}`
-  end
-
-  def heroku_cedar?
-    heroku_cmd(:stack).split("\n").detect {|stack| stack[0] == '*' }.include?('cedar')
-  end
-
-  def heroku?
-    options[:heroku] ||
-      system("grep HOPTOAD_API_KEY config/initializers/hoptoad.rb") ||
-      system("grep HOPTOAD_API_KEY config/environment.rb")
-  end
-
   def use_initializer?
     Rails::VERSION::MAJOR > 1
   end
@@ -93,9 +50,5 @@ class HoptoadGenerator < Rails::Generator::Base
 
   def capistrano_hook
     IO.read(source_path('capistrano_hook.rb'))
-  end
-
-  def plugin_is_present?
-    File.exists?('vendor/plugins/hoptoad_notifier')
   end
 end

--- a/generators/hoptoad/hoptoad_generator.rb
+++ b/generators/hoptoad/hoptoad_generator.rb
@@ -2,6 +2,8 @@ require File.expand_path(File.dirname(__FILE__) + "/lib/insert_commands.rb")
 require File.expand_path(File.dirname(__FILE__) + "/lib/rake_commands.rb")
 
 class HoptoadGenerator < Rails::Generator::Base
+  include HoptoadNotifier::Generator
+
   def add_options!(opt)
     opt.on('-k', '--api-key=key', String, "Your Hoptoad API key")                                               { |v| options[:api_key] = v}
     opt.on('-h', '--heroku',              "Use the Heroku addon to provide your Hoptoad API key")               { |v| options[:heroku]  = v}
@@ -9,10 +11,7 @@ class HoptoadGenerator < Rails::Generator::Base
   end
 
   def manifest
-    if !api_key_configured? && !options[:api_key] && !options[:heroku]
-      puts "Must pass --api-key or --heroku or create config/initializers/hoptoad.rb"
-      exit
-    end
+    require_api_key!
     if plugin_is_present?
       puts "You must first remove the hoptoad_notifier plugin. Please run: script/plugin remove hoptoad_notifier"
       exit

--- a/generators/hoptoad/hoptoad_generator.rb
+++ b/generators/hoptoad/hoptoad_generator.rb
@@ -61,8 +61,17 @@ class HoptoadGenerator < Rails::Generator::Base
   end
 
   def heroku_api_key
-    app = options[:app] ? " --app #{options[:app]}" : ''
-    `heroku console#{app} 'puts ENV[%{HOPTOAD_API_KEY}]'`.split("\n").first
+    cmd = heroku_cedar? ? 'run console' : 'console'
+    heroku_cmd(cmd, "'puts ENV[%{HOPTOAD_API_KEY}]'").split("\n").first
+  end
+
+  def heroku_cmd(cmd, input = nil)
+    app = " --app #{options[:app]}" if options[:app]
+    `heroku #{cmd} #{input} #{app}`
+  end
+
+  def heroku_cedar?
+    heroku_cmd(:stack).split("\n").detect {|stack| stack[0] == '*' }.include?('cedar')
   end
 
   def heroku?

--- a/hoptoad_notifier.gemspec
+++ b/hoptoad_notifier.gemspec
@@ -4,7 +4,7 @@ require "hoptoad_notifier/version"
 
 Gem::Specification.new do |s|
   s.name        = %q{hoptoad_notifier}
-  s.version     = HoptoadNotifier::VERSION
+  s.version     = HoptoadNotifier::VERSION.dup
   s.summary     = %q{Send your application errors to our hosted service and reclaim your inbox.}
 
   s.require_paths = ["lib"]

--- a/lib/hoptoad_notifier.rb
+++ b/lib/hoptoad_notifier.rb
@@ -20,6 +20,8 @@ require 'hoptoad_notifier/railtie' if defined?(Rails::Railtie)
 
 # Gem for applications to automatically post errors to the Hoptoad of their choice.
 module HoptoadNotifier
+  autoload :Heroku, 'hoptoad_notifier/heroku'
+  autoload :Generator, 'hoptoad_notifier/generator'
 
   API_VERSION = "2.0"
   LOG_PREFIX = "** [Hoptoad] "

--- a/lib/hoptoad_notifier/generator.rb
+++ b/lib/hoptoad_notifier/generator.rb
@@ -1,8 +1,45 @@
 module HoptoadNotifier::Generator
+  def heroku
+    @heroku ||= HoptoadNotifier::Heroku.new(options[:app])
+  end
+
   def require_api_key!
     if !api_key_configured? && !options[:api_key] && !options[:heroku]
       puts "Must pass --api-key or --heroku or create config/initializers/hoptoad.rb"
       exit
     end
+  end
+
+  def api_key_expression
+    if options[:api_key]
+      "'#{options[:api_key]}'"
+    elsif options[:heroku]
+      "ENV['HOPTOAD_API_KEY']"
+    end
+  end
+
+  def determine_api_key
+    puts "Attempting to determine your API Key from Heroku..."
+    api_key = heroku.hoptoad_api_key
+    if api_key.blank?
+      puts "... Failed."
+      puts "WARNING: We were unable to detect the Hoptoad API Key from your Heroku environment."
+      puts "Your Heroku application environment may not be configured correctly."
+      exit 1
+    else
+      puts "... Done."
+      puts "Heroku's Hoptoad API Key is '#{api_key}'"
+    end
+    api_key
+  end
+
+  def heroku?
+    options[:heroku] ||
+      system("grep HOPTOAD_API_KEY config/initializers/hoptoad.rb") ||
+      system("grep HOPTOAD_API_KEY config/environment.rb")
+  end
+
+  def plugin_is_present?
+    File.exists?('vendor/plugins/hoptoad_notifier')
   end
 end

--- a/lib/hoptoad_notifier/generator.rb
+++ b/lib/hoptoad_notifier/generator.rb
@@ -1,0 +1,8 @@
+module HoptoadNotifier::Generator
+  def require_api_key!
+    if !api_key_configured? && !options[:api_key] && !options[:heroku]
+      puts "Must pass --api-key or --heroku or create config/initializers/hoptoad.rb"
+      exit
+    end
+  end
+end

--- a/lib/hoptoad_notifier/heroku.rb
+++ b/lib/hoptoad_notifier/heroku.rb
@@ -14,8 +14,8 @@ class HoptoadNotifier::Heroku
 
   private
 
-  def cmd(command, input = nil, pipes = nil)
-    if cedar_stack? && command.to_sym == :console
+  def cmd(command, input = nil)
+    if command.to_sym == :console && cedar_stack?
       # command = 'run console'
       raise "This command doesn't currently work on heroku cedar"
     end

--- a/lib/hoptoad_notifier/heroku.rb
+++ b/lib/hoptoad_notifier/heroku.rb
@@ -15,7 +15,10 @@ class HoptoadNotifier::Heroku
   private
 
   def cmd(command, input = nil, pipes = nil)
-    command = 'run console' if command.to_sym == :console && cedar_stack?
+    if cedar_stack? && command.to_sym == :console
+      # command = 'run console'
+      raise "This command doesn't currently work on heroku cedar"
+    end
     "heroku #{command} #{input} #{@app}"
   end
 

--- a/lib/hoptoad_notifier/heroku.rb
+++ b/lib/hoptoad_notifier/heroku.rb
@@ -1,0 +1,25 @@
+class HoptoadNotifier::Heroku
+
+  def initialize(app = nil)
+    @app = " --app #{app}" if app
+  end
+
+  def rails_env
+    `#{cmd(:console, "'puts RAILS_ENV'")} | head -n 1`.strip
+  end
+
+  def hoptoad_api_key
+    `#{cmd(:console, "'puts ENV[%{HOPTOAD_API_KEY}]'")} | head -n 1`.strip
+  end
+
+  private
+
+  def cmd(command, input = nil, pipes = nil)
+    command = 'run console' if command.to_sym == :console && cedar_stack?
+    "heroku #{command} #{input} #{@app}"
+  end
+
+  def cedar_stack?
+    `#{cmd(:stack)}`.split("\n").detect {|stack| stack[0] == '*' }.include?('cedar')
+  end
+end

--- a/lib/hoptoad_notifier/shared_tasks.rb
+++ b/lib/hoptoad_notifier/shared_tasks.rb
@@ -18,7 +18,6 @@ namespace :hoptoad do
   namespace :heroku do
     desc "Install Heroku deploy notifications addon"
     task :add_deploy_notification => [:environment] do
-      # `heroku console 'puts ENV[%{HOPTOAD_API_KEY}]' | head -n 1`.strip
       heroku = HoptoadNotifier::Heroku.new(ENV['APP'])
       command = %Q(heroku addons:add deployhooks:http url="http://hoptoadapp.com/deploys.txt?deploy[rails_env]=#{heroku.rails_env}&api_key=#{heroku.hoptoad_api_key}")
 

--- a/lib/hoptoad_notifier/shared_tasks.rb
+++ b/lib/hoptoad_notifier/shared_tasks.rb
@@ -18,10 +18,9 @@ namespace :hoptoad do
   namespace :heroku do
     desc "Install Heroku deploy notifications addon"
     task :add_deploy_notification => [:environment] do
-      heroku_api_key = `heroku console 'puts ENV[%{HOPTOAD_API_KEY}]' | head -n 1`.strip
-      heroku_rails_env = `heroku console 'puts RAILS_ENV' | head -n 1`.strip
-
-      command = %Q(heroku addons:add deployhooks:http url="http://hoptoadapp.com/deploys.txt?deploy[rails_env]=#{heroku_rails_env}&api_key=#{heroku_api_key}")
+      # `heroku console 'puts ENV[%{HOPTOAD_API_KEY}]' | head -n 1`.strip
+      heroku = HoptoadNotifier::Heroku.new(ENV['APP'])
+      command = %Q(heroku addons:add deployhooks:http url="http://hoptoadapp.com/deploys.txt?deploy[rails_env]=#{heroku.rails_env}&api_key=#{heroku.hoptoad_api_key}")
 
       puts "\nRunning:\n#{command}\n"
       puts `#{command}`

--- a/lib/rails/generators/hoptoad/hoptoad_generator.rb
+++ b/lib/rails/generators/hoptoad/hoptoad_generator.rb
@@ -1,6 +1,7 @@
 require 'rails/generators'
 
 class HoptoadGenerator < Rails::Generators::Base
+  include HoptoadNotifier::Generator
 
   class_option :api_key, :aliases => "-k", :type => :string, :desc => "Your Hoptoad API key"
   class_option :heroku, :type => :boolean, :desc => "Use the Heroku addon to provide your Hoptoad API key"
@@ -11,7 +12,7 @@ class HoptoadGenerator < Rails::Generators::Base
   end
 
   def install
-    ensure_api_key_was_configured
+    require_api_key!
     ensure_plugin_is_not_present
     append_capistrano_hook
     generate_initializer unless api_key_configured?
@@ -22,13 +23,6 @@ class HoptoadGenerator < Rails::Generators::Base
   end
 
   private
-
-  def ensure_api_key_was_configured
-    if !options[:api_key] && !options[:heroku] && !api_key_configured?
-      puts "Must pass --api-key or --heroku or create config/initializers/hoptoad.rb"
-      exit
-    end
-  end
 
   def ensure_plugin_is_not_present
     if plugin_is_present?

--- a/lib/rails/generators/hoptoad/hoptoad_generator.rb
+++ b/lib/rails/generators/hoptoad/hoptoad_generator.rb
@@ -41,51 +41,8 @@ class HoptoadGenerator < Rails::Generators::Base
     end
   end
 
-  def api_key_expression
-    s = if options[:api_key]
-      "'#{options[:api_key]}'"
-    elsif options[:heroku]
-      "ENV['HOPTOAD_API_KEY']"
-    end
-  end
-
   def generate_initializer
     template 'initializer.rb', 'config/initializers/hoptoad.rb'
-  end
-
-  def determine_api_key
-    puts "Attempting to determine your API Key from Heroku..."
-    api_key = heroku_api_key
-    if api_key.blank?
-      puts "... Failed."
-      puts "WARNING: We were unable to detect the Hoptoad API Key from your Heroku environment."
-      puts "Your Heroku application environment may not be configured correctly."
-      exit 1
-    else
-      puts "... Done."
-      puts "Heroku's Hoptoad API Key is '#{api_key}'"
-    end
-    api_key
-  end
-
-  def heroku_api_key
-    cmd = heroku_cedar? ? 'run console' : 'console'
-    heroku_cmd(cmd, "'puts ENV[%{HOPTOAD_API_KEY}]'").split("\n").first
-  end
-
-  def heroku_cmd(cmd, input = nil)
-    app = " --app #{options[:app]}" if options[:app]
-    `heroku #{cmd} #{input} #{app}`
-  end
-
-  def heroku_cedar?
-    heroku_cmd(:stack).split("\n").detect {|stack| stack[0] == '*' }.include?('cedar')
-  end
-
-  def heroku?
-    options[:heroku] ||
-      system("grep HOPTOAD_API_KEY config/initializers/hoptoad.rb") ||
-      system("grep HOPTOAD_API_KEY config/environment.rb")
   end
 
   def api_key_configured?
@@ -94,9 +51,5 @@ class HoptoadGenerator < Rails::Generators::Base
 
   def test_hoptoad
     puts run("rake hoptoad:test --trace")
-  end
-
-  def plugin_is_present?
-    File.exists?('vendor/plugins/hoptoad_notifier')
   end
 end

--- a/lib/rails/generators/hoptoad/hoptoad_generator.rb
+++ b/lib/rails/generators/hoptoad/hoptoad_generator.rb
@@ -1,4 +1,5 @@
 require 'rails/generators'
+require 'hoptoad_notifier/generator'
 
 class HoptoadGenerator < Rails::Generators::Base
   include HoptoadNotifier::Generator


### PR DESCRIPTION
I was trying to get the generator working on a heroku cedar app and ended up doing some cleanup which DRYs the generator codebase.

Ultimately I wasn't able to get the console command to play nice (a proper solution would probably require IO.popen or the like) so I fail explicitly.

Definitely room for review because this isn't a simple bugfix, so take a look. 
