### PR TITLE
Secure/SSL send certificate fix

### DIFF
--- a/lib/hoptoad_notifier/sender.rb
+++ b/lib/hoptoad_notifier/sender.rb
@@ -34,6 +34,7 @@ module HoptoadNotifier
 
       if secure
         http.use_ssl     = true
+        http.ca_file     = OpenSSL::X509::DEFAULT_CERT_FILE if File.exist?(OpenSSL::X509::DEFAULT_CERT_FILE)
         http.verify_mode = OpenSSL::SSL::VERIFY_PEER
       else
         http.use_ssl     = false

--- a/lib/hoptoad_notifier/sender.rb
+++ b/lib/hoptoad_notifier/sender.rb
@@ -34,7 +34,6 @@ module HoptoadNotifier
 
       if secure
         http.use_ssl     = true
-        http.ca_file     = OpenSSL::X509::DEFAULT_CERT_FILE
         http.verify_mode = OpenSSL::SSL::VERIFY_PEER
       else
         http.use_ssl     = false


### PR DESCRIPTION
For the past 9 days or so Hoptoad has been failing to send on my heroku cedar app with exception: 

``` ruby
OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed
```

due to the fact OpenSSL::X509::DEFAULT_CERT_FILE is set to "/usr/lib/ssl/cert.pem" which doesn't exist, rather "/usr/lib/ssl/certs/" exists as a directory, whose contests AFAICT are the same as "/etc/ssl/certs/".

In any case, things work once again once I remove the ca_file line, so I've made it conditional based on the presence/existence of OpenSSL::X509::DEFAULT_CERT_FILE.
