### PR TITLE
Use result of #original_exception only if it's present.

### DIFF
--- a/lib/hoptoad_notifier.rb
+++ b/lib/hoptoad_notifier.rb
@@ -140,12 +140,12 @@ module HoptoadNotifier
 
     def unwrap_exception(exception)
       if exception.respond_to?(:original_exception)
-        exception.original_exception
+        unwrapped_exception = exception.original_exception
       elsif exception.respond_to?(:continued_exception)
-        exception.continued_exception
-      else
-        exception
+        unwrapped_exception = exception.continued_exception
       end
+
+      unwrapped_exception.nil? ? exception : unwrapped_exception
     end
   end
 end

--- a/test/notifier_test.rb
+++ b/test/notifier_test.rb
@@ -202,7 +202,7 @@ class NotifierTest < Test::Unit::TestCase
       assert_nil @hash[:controller]
     end
 
-    context "when an exception that provides #original_exception is raised" do
+    context "when an exception that provides meaning #original_exception is raised" do
       setup do
         @exception.stubs(:original_exception).returns(begin
           raise NotifierTest::OriginalException.new
@@ -217,7 +217,18 @@ class NotifierTest < Test::Unit::TestCase
       end
     end
 
-    context "when an exception that provides #continued_exception is raised" do
+    context "when an exception that provides useless #original_exception is raised" do
+      setup do
+        @exception.stubs(:original_exception).returns(nil)
+      end
+
+      should "not unwrap exceptions that provide #original_exception" do
+        @hash = HoptoadNotifier.build_lookup_hash_for(@exception)
+        assert_equal @exception.class.to_s, @hash[:error_class]
+      end
+    end
+
+    context "when an exception that provides meaning #continued_exception is raised" do
       setup do
         @exception.stubs(:continued_exception).returns(begin
           raise NotifierTest::ContinuedException.new


### PR DESCRIPTION
Seems logical, helps with some Exception monkey-patches.
