### PR TITLE
Verify HoptoadNotifier.configuration is not nil in Rake

### DIFF
--- a/lib/hoptoad_notifier/rake_handler.rb
+++ b/lib/hoptoad_notifier/rake_handler.rb
@@ -9,12 +9,13 @@ module HoptoadNotifier::RakeHandler
   end
 
   def display_error_message_with_hoptoad(ex)
-    if HoptoadNotifier.configuration.rescue_rake_exceptions || 
-        (HoptoadNotifier.configuration.rescue_rake_exceptions===nil && !self.tty_output?)
+    if HoptoadNotifier.configuration  
+      if HoptoadNotifier.configuration.rescue_rake_exceptions || 
+          (HoptoadNotifier.configuration.rescue_rake_exceptions===nil && !self.tty_output?)
 
-      HoptoadNotifier.notify(ex, :component => reconstruct_command_line, :cgi_data => ENV)
+        HoptoadNotifier.notify(ex, :component => reconstruct_command_line, :cgi_data => ENV)
+      end
     end
-
     display_error_message_without_hoptoad(ex)
   end
 


### PR DESCRIPTION
Hi,

I noticed a slight bug in the RakeHandler module which occurs when you attempt to execute a rake task that does not exist.

As the task does not exist the configuration for Hoptoad is not loaded, and as such a NoMethodError on nil comes up.

The pull request has a simple sanity check for the object before attempting to use it.

Thanks!
