### PR TITLE
bug in user_informer middleware

### DIFF
--- a/lib/hoptoad_notifier/user_informer.rb
+++ b/lib/hoptoad_notifier/user_informer.rb
@@ -5,7 +5,7 @@ module HoptoadNotifier
     end
 
     def replacement(with)
-      @replacement ||= HoptoadNotifier.configuration.user_information.gsub(/\{\{\s*error_id\s*\}\}/, with.to_s)
+      HoptoadNotifier.configuration.user_information.gsub(/\{\{\s*error_id\s*\}\}/, with.to_s)
     end
 
     def call(env)


### PR DESCRIPTION
Hi,

I think I stumbled across a bug in the user_informer - for me it always showed the same error id (always that of the first error to occur after an app restart), even if new errors were created. Reason: in user_informer.rb you're putting the replacement text into a global, which isn't a good thing imho as the middleware instance appears to be re-used across requests. Update: While the global might be fine (as long as no threads are involved), using it as a cache with ||= isn't.

Happened to me in a Rails 2.3.14 / 1.8.7 / Passenger environment, and removing the global fixed it.

Cheers,
Jens
